### PR TITLE
change payload to param

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,7 +11,7 @@ export type ProviderParams =
 	}
 	| {
 		provider: 'github-claim'
-		payload: GithubParams
+		parameters: GithubParams
 	}
 	| {
 		provider: 'http'


### PR DESCRIPTION
There's some type issues with payload right now so we better keep it parameters. So i'll keep the payload PR on hold for now