### PR TITLE
Add context

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,9 @@ Here's a step-by-step guide to help you get started:
     try {
         const request = reclaim.requestProofs({
             title: "Reclaim Protocol",
-            baseCallbackUrl: "https://reclaim.app/callback",
+            baseCallbackUrl: "https://reclaim.app/callback", 
+            contextMessage: "Airdrop for Reclaim claimants", //optional: context message for the proof request
+            contextAddress: "0x5d96Cb97F8499d4dEa814cEa2F8448A0AF1A2bC2" //optional: your users' Ethereum wallet address
             requestedProofs: [
                 new reclaim.CustomProvider({
                     provider: 'google-login',
@@ -82,7 +84,8 @@ Here's a step-by-step guide to help you get started:
             ],
         });
         // Store the callback Id and Reclaim URL in your database
-        const { callbackId, reclaimUrl } = request;
+        const { callbackId } = request;
+        const reclaimUrl = await request.getReclaimUrl();
         // ... store the callbackId and reclaimUrl in your database
         res.json({ reclaimUrl });
     }
@@ -204,7 +207,8 @@ app.get("/request-proofs", (req, res) => {
             ],
         });
         // Store the callback Id, Reclaim URL and expectedProofsInCallback in your database
-        const { callbackId, reclaimUrl, expectedProofsInCallback } = request;
+        const { callbackId, expectedProofsInCallback } = request;
+        const reclaimUrl = await request.getReclaimUrl()
         // ... store the callbackId, reclaimUrl and expectedProofsInCallback in your database
         res.json({ reclaimUrl });
     }

--- a/docs/using-the-reclaim-sdk/using-the-https-provider.md
+++ b/docs/using-the-reclaim-sdk/using-the-https-provider.md
@@ -41,6 +41,8 @@ app.get("/request-proofs", (req, res) => {
     const request = reclaim.requestProofs({
         title: "Reclaim Protocol",
         baseCallbackUrl: "https://yourdomain.com/callback",
+        contextMessage: "Airdrop for Reclaim claimants", //optional: context message for the proof request
+        contextAddress: "0x5d96Cb97F8499d4dEa814cEa2F8448A0AF1A2bC2" //optional: your users' Ethereum wallet 
         requestedProofs: [
             new reclaim.HttpsProvider({
                 name: "Reddit Karma",
@@ -53,7 +55,8 @@ app.get("/request-proofs", (req, res) => {
         ],
     });
 
-    const { callbackId, reclaimUrl, expectedProofsInCallback } = request;
+    const { callbackId, expectedProofsInCallback } = request;
+    const reclaimUrl = await request.getReclaimUrl();
     // Save the callbackId, reclaimUrl, and expectedProofsInCallback for future use
     // ...
     res.json({ reclaimUrl });

--- a/src/ReclaimProtocol/Reclaim.ts
+++ b/src/ReclaimProtocol/Reclaim.ts
@@ -27,18 +27,19 @@ export class Reclaim {
 	 */
 	requestProofs = (request: ProofRequest): TemplateInstance => {
 		const callbackUrl = generateCallbackUrl(request.baseCallbackUrl, request.callbackId)
+		const contextMessage = request.contextMessage ? request.contextMessage : request.baseCallbackUrl
+		const contextAddress = request.contextAddress ? request.contextAddress : '0x0'
 		const template: Template = {
 			id: generateUuid(),
 			name: request.title,
 			callbackUrl,
-			contextMessage: request.contextMessage ? request.contextMessage : request.baseCallbackUrl,
-			contextAddress: request.contextAddress ? request.contextAddress : '0x00',
 			claims: request.requestedProofs.map((requestedProof) => {
 				return {
 					templateClaimId: generateUuid(),
 					// eslint-disable-next-line @typescript-eslint/no-explicit-any
 					provider: requestedProof.params.provider as any,
 					payload: requestedProof.params.payload,
+					context: utils.keccak256(utils.toUtf8Bytes(contextMessage)) + '' + contextAddress,
 				}
 			})
 		}

--- a/src/ReclaimProtocol/Reclaim.ts
+++ b/src/ReclaimProtocol/Reclaim.ts
@@ -26,10 +26,13 @@ export class Reclaim {
 	 * @returns {TemplateInstance} Template instance
 	 */
 	requestProofs = (request: ProofRequest): TemplateInstance => {
+		const callbackUrl = generateCallbackUrl(request.baseCallbackUrl, request.callbackId)
 		const template: Template = {
 			id: generateUuid(),
 			name: request.title,
-			callbackUrl: generateCallbackUrl(request.baseCallbackUrl, request.callbackId), // if callbackId is present, use it, else generate a new callback url
+			callbackUrl,
+			contextMessage: request.contextMessage ? request.contextMessage : callbackUrl,
+			contextAddress: request.contextAddress ? request.contextAddress : '0x00',
 			claims: request.requestedProofs.map((requestedProof) => {
 				return {
 					templateClaimId: generateUuid(),

--- a/src/ReclaimProtocol/Reclaim.ts
+++ b/src/ReclaimProtocol/Reclaim.ts
@@ -31,7 +31,7 @@ export class Reclaim {
 			id: generateUuid(),
 			name: request.title,
 			callbackUrl,
-			contextMessage: request.contextMessage ? request.contextMessage : callbackUrl,
+			contextMessage: request.contextMessage ? request.contextMessage : request.baseCallbackUrl,
 			contextAddress: request.contextAddress ? request.contextAddress : '0x00',
 			claims: request.requestedProofs.map((requestedProof) => {
 				return {

--- a/src/tests/test.validateparameters.ts
+++ b/src/tests/test.validateparameters.ts
@@ -88,6 +88,7 @@ const PROOFS_WITHOUT_XPATH: Proof[] = [
 				{ 'responseMatch': "<span id='empid'>9845</span>" },
 			]
 		},
+		'context': '0xb6d6fb002c789cae7ee1bb3b184dbcbe53d20357f824466057c7e3f1579c7c800x0',
 		'chainId': 420,
 		'ownerPublicKey': '03057dd1b36d108cc0d9bced0565b6363ed910bc6522aa937092e1dc344614ddde',
 		'timestampS': '1684343138',
@@ -99,6 +100,7 @@ const PROOFS_WITHOUT_XPATH: Proof[] = [
 		'onChainClaimId': '2617',
 		'sessionId': '0', // TODO: update this once the app integrates sessionId into the proof
 		'templateClaimId': '0',
+		'context': '0xb6d6fb002c789cae7ee1bb3b184dbcbe53d20357f824466057c7e3f1579c7c800x0',
 		'provider': 'http',
 		'parameters': {
 			'url': 'https://www.reddit.com',
@@ -120,6 +122,7 @@ const PROOFS_WITHOUT_XPATH: Proof[] = [
 		'onChainClaimId': '2617',
 		'sessionId': '0', // TODO: update this once the app integrates sessionId into the proof
 		'templateClaimId': '0',
+		'context': '0xb6d6fb002c789cae7ee1bb3b184dbcbe53d20357f824466057c7e3f1579c7c800x0',
 		'provider': 'http',
 		'parameters': {
 			'emailAddress': 'abc@gmail.com'
@@ -138,6 +141,7 @@ const PROOFS_WITH_XPATH: Proof[] = [
 	{
 		'chainId': 420,
 		'sessionId': '0', // TODO: update this once the app integrates sessionId into the proof
+		'context': '0xb6d6fb002c789cae7ee1bb3b184dbcbe53d20357f824466057c7e3f1579c7c800x0',
 		'onChainClaimId': '6607',
 		'ownerPublicKey': '0217aff403993ec235b028c89e7148927a971fc1b6bcdc01d276ca48659f76b404',
 		'parameters': {

--- a/src/tests/test.verification.ts
+++ b/src/tests/test.verification.ts
@@ -107,6 +107,7 @@ const EXPECTED_SESSION_ID = '0' // TODO: update this with valid session id once 
 const CORRECT_PROOF: Proof = {
 	onChainClaimId: '1560',
 	sessionId: '0', // TODO: update this once the app integrates sessionId into the proof
+	context: '0xb6d6fb002c789cae7ee1bb3b184dbcbe53d20357f824466057c7e3f1579c7c800x0', // TODO: update this once the app integrates context into the proof
 	templateClaimId: generateUuid(),
 	chainId: 420,
 	provider: 'google-login',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -20,7 +20,14 @@ export type ProofRequest = {
 	 * Callback id
 	 */
 	callbackId?: string
+	/**
+	 * Context message for the proof request
+	 */
 	contextMessage?: string
+	/**
+	 * Context address for the proof request
+	 * This is your users' ethereum wallet address
+	 */
 	contextAddress?: string
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -20,6 +20,8 @@ export type ProofRequest = {
 	 * Callback id
 	 */
 	callbackId?: string
+	contextMessage?: string
+	contextAddress?: string
 }
 
 export type HttpsProviderParams = {
@@ -136,6 +138,8 @@ export type Template = {
 	name: string
 	callbackUrl: string
 	claims: Claim[]
+	contextMessage: string
+	contextAddress: string
 }
 
 export type ProofClaim = Omit<Claim, 'payload'> & {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -138,6 +138,7 @@ export type responseSelection = {
 
 export type Claim = {
 	templateClaimId: string
+	context: string
 } & ProviderParams
 
 export type Template = {
@@ -145,8 +146,6 @@ export type Template = {
 	name: string
 	callbackUrl: string
 	claims: Claim[]
-	contextMessage: string
-	contextAddress: string
 }
 
 export type ProofClaim = Omit<Claim, 'payload'> & {


### PR DESCRIPTION
This PR adds two additional parameters that can be passed as part of Proof Request:
- `contextMessage` - Requestor can pass the context for requesting proofs from their users
- `contextAddress`- Requestor can pass their users' wallet address to avoid front run by another address by the miner